### PR TITLE
[REVIEW]: Display plot in tutorial `plot_syn_red_mmi.py`

### DIFF
--- a/examples/metrics/plot_syn_red_mmi.py
+++ b/examples/metrics/plot_syn_red_mmi.py
@@ -201,6 +201,8 @@ plot_landscape(
     plt_kwargs=dict(cmap="turbo"),
 )
 
+plt.show()
+
 # %%
 # Plotting synergy
 
@@ -211,3 +213,5 @@ plot_landscape(
     undersampling=False,
     plt_kwargs=dict(cmap="turbo"),
 )
+
+plt.show()


### PR DESCRIPTION
Dear authors, 

This simple PR simply adds missing `plt.show()` at the end of the tutorial script `examples/metrics/plot_syn_red_mmi.py`.

REVIEW ISSUE: https://github.com/openjournals/joss-reviews/issues/7360