### PR TITLE
[REVIEW]: Display plot in tutorial `plot_bootstrapping.py`

### DIFF
--- a/examples/statistics/plot_bootstrapping.py
+++ b/examples/statistics/plot_bootstrapping.py
@@ -193,6 +193,8 @@ plt.xlabel("Multiplet")
 plt.ylabel("Oinfo [bits]")
 plt.title("O-information with [5, 95]% confidence interval", fontweight="bold")
 
+plt.show()
+
 # %%
 # This time, the O-information and confidence interval surrounding the
 # multiplet (0, 1, 2, 3) doesn't includes the confidence interval of lower


### PR DESCRIPTION
Dear authors, 

This simple PR simply adds missing `plt.show()` at the end of the tutorial script `examples/statistics/plot_bootstrapping.py`.

REVIEW ISSUE: https://github.com/openjournals/joss-reviews/issues/7360